### PR TITLE
core/imagemagick updated to 7.0.9, and as part of the major version b…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
-    rmagick (2.16.0)
+    rmagick (4.1.1)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)


### PR DESCRIPTION
This commit comes from Scott Macfarlane's update to the chef-training/habitat-building-dependencies repo, and applies here

core/imagemagick updated to 7.0.9, and as part of the major version bump, ImageMagick has moved their header files from `include/ImageMagic-6/wand` to `include/ImageMagic-7/MagicWand`.  The version currently in the Gemfile (2.1.1) doesn't understand the change in directories and attempts to include `wand/MagickWand.h`, which has been moved to `MagicWand/MagickWand.h`. The latest version `4.1.1` corrects this.

Signed-off-by: Robin Beck <stellarsquall@protonmail.ch>