### PR TITLE
Move to bundler 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.1)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.0.8.1)
       rack
-    rmagick (4.1.1)
-    sinatra (2.0.0)
+    rmagick (4.1.2)
+    ruby2_keywords (0.0.2)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    tilt (2.0.8)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby
@@ -21,4 +23,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.15.4
+   2.1.4


### PR DESCRIPTION
I was able to get the package building in Habitat with this change but
haven't tested it beyond that.

This fixes the Habitat build because, as far as I can tell, the
breakage looks something like this:

1) Bundler 2 has a feature where, when it detects a Gemfile bundled
   with an older Gemfile, it tries to switch to that major version.

2) In the case of core/bundler this meant that when you ran bundle
   inside this repository, it would report its version as 1.16.6 which
   is the version that shipped with the version of Ruby core/bundler
   is using.

3) The scaffolding assumes that it can always find a gem for the
   version reported by `bundle --version` in the /hab/pkg path for
   core/bundler.  However, because of the version-switching feature,
   this is not the case.

   https://github.com/habitat-sh/core-plans/blob/master/scaffolding-ruby/lib/scaffolding.sh#L350-L352

Upgrading to 2.1 in Gemfile means that core/bundler doesn't switch to
a 1.x version and thus the version reported by `bundle --version` is
indeed available for the scaffolding to vendor.

Signed-off-by: Steven Danna <steve@chef.io>